### PR TITLE
Metamask Listen to Account Change

### DIFF
--- a/components/v1/Buttons/ConnectWalletDesktop.tsx
+++ b/components/v1/Buttons/ConnectWalletDesktop.tsx
@@ -48,11 +48,11 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
 
     // Listen to wallet address change in metamask
     useEffect(() => {
-        if(account && accountData.data?.address){
+        if (account && accountData.data?.address) {
             logout();
-            login(accountData.data.address)
+            login(accountData.data.address);
         }
-        console.log(accountData.data)
+        console.log(accountData.data);
     }, [accountData.data?.address]);
 
     // Popover

--- a/components/v1/Buttons/ConnectWalletDesktop.tsx
+++ b/components/v1/Buttons/ConnectWalletDesktop.tsx
@@ -52,7 +52,6 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
             logout();
             login(accountData.data.address);
         }
-        console.log(accountData.data);
     }, [accountData.data?.address]);
 
     // Popover

--- a/components/v1/Buttons/ConnectWalletDesktop.tsx
+++ b/components/v1/Buttons/ConnectWalletDesktop.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Popover } from "@headlessui/react";
 import Link from "next/link";
 import type { FunctionComponent } from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import { usePopper } from "react-popper";
 import { Chain, chain as Chains, InjectedConnector, useAccount, useConnect, useNetwork } from "wagmi";
@@ -45,6 +45,15 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
     const [accountData, disconnect] = useAccount();
     let [isOpen, setIsOpen] = useState(false);
     let [isConnecting, setIsConnecting] = useState(false);
+
+    // Listen to wallet address change in metamask
+    useEffect(() => {
+        if(account && accountData.data?.address){
+            logout();
+            login(accountData.data.address)
+        }
+        console.log(accountData.data)
+    }, [accountData.data?.address]);
 
     // Popover
     let [referenceElement1, setReferenceElement1] = useState<HTMLButtonElement | null>();

--- a/components/v1/Buttons/ConnectWalletMobile.tsx
+++ b/components/v1/Buttons/ConnectWalletMobile.tsx
@@ -47,9 +47,9 @@ const ButtonConnectWalletMobile: FunctionComponent<ButtonConnectWalletMobileProp
 
     // Listen to wallet address change in metamask
     useEffect(() => {
-        if(account && accountData.data?.address){
+        if (account && accountData.data?.address) {
             logout();
-            login(accountData.data.address)
+            login(accountData.data.address);
         }
     }, [accountData.data?.address]);
 

--- a/components/v1/Buttons/ConnectWalletMobile.tsx
+++ b/components/v1/Buttons/ConnectWalletMobile.tsx
@@ -1,7 +1,7 @@
 import { Popover } from "@headlessui/react";
 import Link from "next/link";
 import type { FunctionComponent } from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import { usePopper } from "react-popper";
 import { Chain, chain as Chains, InjectedConnector, useAccount, useConnect, useNetwork } from "wagmi";
@@ -44,6 +44,14 @@ const ButtonConnectWalletMobile: FunctionComponent<ButtonConnectWalletMobileProp
     const [connectedChain, switchNetwork] = useNetwork();
     const [accountData, disconnect] = useAccount();
     let [isConnecting, setIsConnecting] = useState(false);
+
+    // Listen to wallet address change in metamask
+    useEffect(() => {
+        if(account && accountData.data?.address){
+            logout();
+            login(accountData.data.address)
+        }
+    }, [accountData.data?.address]);
 
     // Popover state element
     let [referenceElement1, setReferenceElement1] = useState<HTMLButtonElement | null>();


### PR DESCRIPTION
When user change their wallet address from Metamask, the address shown on the website & the transaction signer will now change too.