### PR TITLE
Minor UI Improvement

### DIFF
--- a/components/v1/MarketDetailPage/DepositForm.tsx
+++ b/components/v1/MarketDetailPage/DepositForm.tsx
@@ -179,15 +179,18 @@ const DepositForm: FunctionComponent<DepositFormProps> = ({ address }) => {
                         <div className="text-center">
                             <p className="flex justify-center text-xs leading-4 text-gray-light-10 dark:text-gray-dark-10">
                                 You will get
-                                <span className="flex font-semibold text-gray-light-12 dark:text-gray-dark-12 ml-1">
-                                    {exchangeRateResponse.isLoading ? 
+                                <span className="ml-1 flex font-semibold text-gray-light-12 dark:text-gray-dark-12">
+                                    {exchangeRateResponse.isLoading ? (
                                         <svg width="17" height="16" viewBox="0 0 17 16" className="mx-2 animate-spin fill-gray-light-12 dark:fill-gray-dark-12" xmlns="http://www.w3.org/2000/svg">
                                             <g clipPath="url(#clip0_1161_30088)">
                                                 <path opacity="0.2" d="M16.5 8.00049C16.5 12.4188 12.9183 16.0005 8.5 16.0005C4.08172 16.0005 0.5 12.4188 0.5 8.00049C0.5 3.58221 4.08172 0.000488281 8.5 0.000488281C12.9183 0.000488281 16.5 3.58221 16.5 8.00049ZM2.9 8.00049C2.9 11.0933 5.40721 13.6005 8.5 13.6005C11.5928 13.6005 14.1 11.0933 14.1 8.00049C14.1 4.90769 11.5928 2.40049 8.5 2.40049C5.40721 2.40049 2.9 4.90769 2.9 8.00049Z" />
                                                 <path d="M15.3 8.00049C15.9627 8.00049 16.5092 8.5407 16.4102 9.196C16.3136 9.83526 16.1396 10.4619 15.891 11.062C15.489 12.0326 14.8997 12.9145 14.1569 13.6573C13.414 14.4002 12.5321 14.9895 11.5615 15.3915C10.9614 15.6401 10.3348 15.814 9.69551 15.9107C9.04021 16.0097 8.5 15.4632 8.5 14.8005C8.5 14.1377 9.04326 13.6133 9.69084 13.4724C10.0157 13.4017 10.3344 13.3021 10.643 13.1742C11.3224 12.8928 11.9398 12.4803 12.4598 11.9603C12.9798 11.4403 13.3923 10.8229 13.6737 10.1435C13.8016 9.83489 13.9012 9.51619 13.9719 9.19133C14.1129 8.54375 14.6373 8.00049 15.3 8.00049Z" />
                                             </g>
-                                        </svg> 
-                                        : tokenBalanceFormatter.format(rvTokenAmount)} {metadata.vaultTitle}
+                                        </svg>
+                                    ) : (
+                                        tokenBalanceFormatter.format(rvTokenAmount)
+                                    )}{" "}
+                                    {metadata.vaultTitle}
                                 </span>
                             </p>
                         </div>

--- a/components/v1/MarketDetailPage/DepositForm.tsx
+++ b/components/v1/MarketDetailPage/DepositForm.tsx
@@ -65,7 +65,7 @@ const DepositForm: FunctionComponent<DepositFormProps> = ({ address }) => {
     );
 
     // UI States
-    const showLoading = balanceResponse.isLoading || exchangeRateResponse.isLoading ? true : false;
+    const showLoading = balanceResponse.isLoading ? true : false;
     const showError = !showLoading && (balanceResponse.error || exchangeRateResponse.error) ? true : false;
     const showForm = !showLoading && !showError;
 
@@ -177,10 +177,17 @@ const DepositForm: FunctionComponent<DepositFormProps> = ({ address }) => {
 
                         {/* Exhange rate */}
                         <div className="text-center">
-                            <p className="text-xs leading-4 text-gray-light-10 dark:text-gray-dark-10">
-                                You will get{" "}
-                                <span className="font-semibold text-gray-light-12 dark:text-gray-dark-12">
-                                    {tokenBalanceFormatter.format(rvTokenAmount)} {metadata.vaultTitle}
+                            <p className="flex justify-center text-xs leading-4 text-gray-light-10 dark:text-gray-dark-10">
+                                You will get
+                                <span className="flex font-semibold text-gray-light-12 dark:text-gray-dark-12 ml-1">
+                                    {exchangeRateResponse.isLoading ? 
+                                        <svg width="17" height="16" viewBox="0 0 17 16" className="mx-2 animate-spin fill-gray-light-12 dark:fill-gray-dark-12" xmlns="http://www.w3.org/2000/svg">
+                                            <g clipPath="url(#clip0_1161_30088)">
+                                                <path opacity="0.2" d="M16.5 8.00049C16.5 12.4188 12.9183 16.0005 8.5 16.0005C4.08172 16.0005 0.5 12.4188 0.5 8.00049C0.5 3.58221 4.08172 0.000488281 8.5 0.000488281C12.9183 0.000488281 16.5 3.58221 16.5 8.00049ZM2.9 8.00049C2.9 11.0933 5.40721 13.6005 8.5 13.6005C11.5928 13.6005 14.1 11.0933 14.1 8.00049C14.1 4.90769 11.5928 2.40049 8.5 2.40049C5.40721 2.40049 2.9 4.90769 2.9 8.00049Z" />
+                                                <path d="M15.3 8.00049C15.9627 8.00049 16.5092 8.5407 16.4102 9.196C16.3136 9.83526 16.1396 10.4619 15.891 11.062C15.489 12.0326 14.8997 12.9145 14.1569 13.6573C13.414 14.4002 12.5321 14.9895 11.5615 15.3915C10.9614 15.6401 10.3348 15.814 9.69551 15.9107C9.04021 16.0097 8.5 15.4632 8.5 14.8005C8.5 14.1377 9.04326 13.6133 9.69084 13.4724C10.0157 13.4017 10.3344 13.3021 10.643 13.1742C11.3224 12.8928 11.9398 12.4803 12.4598 11.9603C12.9798 11.4403 13.3923 10.8229 13.6737 10.1435C13.8016 9.83489 13.9012 9.51619 13.9719 9.19133C14.1129 8.54375 14.6373 8.00049 15.3 8.00049Z" />
+                                            </g>
+                                        </svg> 
+                                        : tokenBalanceFormatter.format(rvTokenAmount)} {metadata.vaultTitle}
                                 </span>
                             </p>
                         </div>

--- a/components/v1/MarketDetailPage/ETHRISEPage.tsx
+++ b/components/v1/MarketDetailPage/ETHRISEPage.tsx
@@ -245,7 +245,7 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                                     </div>
                                     <div className="flex flex-row justify-between">
                                         <p className="text-sm leading-4 text-gray-light-10 dark:text-gray-dark-10">Contract Address</p>
-                                        <a href={getEtherscanAddressURL(chain.chain, ethriseAddress)} target="_blank" className="font-ibm text-sm font-semibold leading-4 tracking-[-.02em] text-gray-light-12 dark:text-gray-dark-12">
+                                        <a href={getEtherscanAddressURL(chain.chain, ethriseAddress)} target="_blank" rel="noreferrer" className="font-ibm text-sm font-semibold leading-4 tracking-[-.02em] text-gray-light-12 dark:text-gray-dark-12">
                                             {formatAddress(ethriseAddress)} &#8599;
                                         </a>
                                     </div>

--- a/components/v1/MarketDetailPage/ETHRISEPage.tsx
+++ b/components/v1/MarketDetailPage/ETHRISEPage.tsx
@@ -140,8 +140,8 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                                     <Tabs.Trigger value="leverage" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
                                         Leverage
                                     </Tabs.Trigger>
-                                    <Tabs.Trigger value="earn" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
-                                        Earn
+                                    <Tabs.Trigger value="lend" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
+                                        Lend
                                     </Tabs.Trigger>
                                 </Tabs.List>
                             </div>
@@ -152,8 +152,8 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                             <Tabs.Trigger value="leverage" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
                                 Leverage
                             </Tabs.Trigger>
-                            <Tabs.Trigger value="earn" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
-                                Earn
+                            <Tabs.Trigger value="lend" className="basis-1/2 rounded-[8px] text-sm leading-4 text-gray-light-10 state-active:bg-gray-light-1 state-active:py-[12px] state-active:font-bold state-active:text-gray-light-12 dark:text-gray-dark-10 state-active:dark:bg-gray-dark-4 state-active:dark:text-gray-dark-12">
+                                Lend
                             </Tabs.Trigger>
                         </Tabs.List>
 
@@ -256,8 +256,8 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                             <BackingCard address={ethriseAddress} />
                         </Tabs.Content>
 
-                        {/* Earn tab */}
-                        <Tabs.Content value="earn" className="mx-auto flex max-w-[540px] flex-col space-y-6 outline-0">
+                        {/* Lend tab */}
+                        <Tabs.Content value="lend" className="mx-auto flex max-w-[540px] flex-col space-y-6 outline-0">
                             {/* APY info card */}
                             <div className="flex w-full flex-col rounded-[16px] bg-gray-light-2 dark:bg-gray-dark-2">
                                 {/* Title, subtitle and lgoo */}

--- a/components/v1/MarketDetailPage/ETHRISEPage.tsx
+++ b/components/v1/MarketDetailPage/ETHRISEPage.tsx
@@ -245,7 +245,7 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                                     </div>
                                     <div className="flex flex-row justify-between">
                                         <p className="text-sm leading-4 text-gray-light-10 dark:text-gray-dark-10">Contract Address</p>
-                                        <a href={getEtherscanAddressURL(chain.chain, ethriseAddress)} target="_blank" rel="noreferrer" className="font-ibm text-sm font-semibold leading-4 tracking-[-.02em] text-gray-light-12 dark:text-gray-dark-12">
+                                        <a href={getEtherscanAddressURL(chain.chain, ethriseAddress)} target="_blank" rel="noopener noreferrer" className="font-ibm text-sm font-semibold leading-4 tracking-[-.02em] text-gray-light-12 dark:text-gray-dark-12">
                                             {formatAddress(ethriseAddress)} &#8599;
                                         </a>
                                     </div>

--- a/components/v1/MarketDetailPage/ETHRISEPage.tsx
+++ b/components/v1/MarketDetailPage/ETHRISEPage.tsx
@@ -7,7 +7,7 @@ import toast, { Toaster } from "react-hot-toast";
 
 import Favicon from "../Favicon";
 import Footer from "../Footer";
-import { DEFAULT_CHAIN, useWalletContext } from "../Wallet";
+import { DEFAULT_CHAIN, useWalletContext, getEtherscanAddressURL, formatAddress } from "../Wallet";
 import { Metadata } from "../MarketMetadata";
 import { useMarket } from "../../../utils/snapshot";
 import { dollarFormatter } from "../../../utils/formatters";
@@ -242,6 +242,12 @@ const ETHRISEPage: FunctionComponent<ETHRISEPageProps> = ({}) => {
                                                 {market.leveraged_token_max_total_collateral <= 0 && <span>&#8734;</span>}
                                             </p>
                                         )}
+                                    </div>
+                                    <div className="flex flex-row justify-between">
+                                        <p className="text-sm leading-4 text-gray-light-10 dark:text-gray-dark-10">Contract Address</p>
+                                        <a href={getEtherscanAddressURL(chain.chain, ethriseAddress)} target="_blank" className="font-ibm text-sm font-semibold leading-4 tracking-[-.02em] text-gray-light-12 dark:text-gray-dark-12">
+                                            {formatAddress(ethriseAddress)} &#8599;
+                                        </a>
                                     </div>
                                 </div>
                             </div>

--- a/components/v1/MarketDetailPage/LeveragedTokenChart.tsx
+++ b/components/v1/MarketDetailPage/LeveragedTokenChart.tsx
@@ -116,7 +116,7 @@ const LeveragedTokenChart: FunctionComponent<LeveragedTokenChartProps> = ({ addr
                                         const selectedData = payload[0].payload;
                                         const timestamp = selectedData.timestamp;
                                         const date = new Date(timestamp);
-                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "numeric", year: "numeric", minute: "numeric" }).format(date);
+                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "short", year: "numeric", minute: "numeric" }).format(date);
 
                                         setNAV(selectedData.nav);
                                         const change = ((selectedData.nav - currentData.oldestNAV) / currentData.oldestNAV) * 100;

--- a/components/v1/MarketDetailPage/VaultChart.tsx
+++ b/components/v1/MarketDetailPage/VaultChart.tsx
@@ -92,7 +92,7 @@ const VaultChart: FunctionComponent<VaultChartProps> = ({ address }) => {
                                         const selectedData = payload[0].payload;
                                         const timestamp = selectedData.timestamp;
                                         const date = new Date(timestamp);
-                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "numeric", year: "numeric", minute: "numeric" }).format(date);
+                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "short", year: "numeric", minute: "numeric" }).format(date);
 
                                         setSupplyAPY(selectedData.supply_apy);
                                         setBorrowAPY(selectedData.borrow_apy);

--- a/components/v1/MarketsPage/MarketCard.tsx
+++ b/components/v1/MarketsPage/MarketCard.tsx
@@ -106,7 +106,7 @@ const MarketCard: FunctionComponent<MarketCardProps> = ({ address, initialNAV, i
                                         const selectedData = payload[0].payload;
                                         const timestamp = selectedData.timestamp;
                                         const date = new Date(timestamp);
-                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "numeric", year: "numeric", minute: "numeric" }).format(date);
+                                        const formattedDate = new Intl.DateTimeFormat("en-US", { hour: "numeric", day: "numeric", month: "short", year: "numeric", minute: "numeric" }).format(date);
 
                                         setNAV(selectedData.nav);
                                         const change = ((selectedData.nav - currentData.oldestNAV) / currentData.oldestNAV) * 100;


### PR DESCRIPTION
## #106 Change Date Format in Charts
### Before: 
![image](https://user-images.githubusercontent.com/81855912/153072471-7d37b775-d8f7-4e17-8d03-951aaed7f027.png)
### After:
![image](https://user-images.githubusercontent.com/81855912/153072407-6a58704d-5158-4188-96e2-78caf77809a9.png)

## #102 Fix DepositForm Loading
### Before:
Wait for USDC balance & exchange rate data to load the DepositForm
### After:
Only wait for USDC balance to load the DepositForm, and then we will show a spinner when exchange rate is still loading like the picture below
![image](https://user-images.githubusercontent.com/81855912/153073217-3be1ade6-0d1c-4de1-9a9c-44bf712c4536.png)

## #104 Add Contract Address & Link to Explorer for Leveraged Token
Add contract address information to leveraged token and when user press it, it will open the contract address on block explorer (e.g Arbiscan) in new tab.
![image](https://user-images.githubusercontent.com/81855912/153073818-c9c9398f-99b9-494f-89cd-54944b661d68.png)

## #110 Rename 'Earn' to 'Lend' in ETHRISE Page
![image](https://user-images.githubusercontent.com/81855912/153074192-bfeb8401-9fe0-41e4-a842-42208add240e.png)