### PR TITLE
Remove Kovan from Supported Chain (#196)

### DIFF
--- a/components/v1/Buttons/NetworkSwitcher.tsx
+++ b/components/v1/Buttons/NetworkSwitcher.tsx
@@ -33,8 +33,6 @@ const ButtonNetworkSwitcher: FunctionComponent<ButtonNetworkSwitcherProps> = ({}
         switch (c.id) {
             case Chains.arbitrumOne.id:
                 return "/networks/Arbitrum.svg";
-            case Chains.kovan.id:
-                return "/networks/Kovan.svg";
         }
         return "/networks/Arbitrum.svg";
     };

--- a/components/v1/MarketDetailPage/ETHRISEPage.tsx
+++ b/components/v1/MarketDetailPage/ETHRISEPage.tsx
@@ -33,7 +33,6 @@ import Navigation from "../Navigation";
 
 // ETHRISE Token ids
 const ETHRISEAddresses = {
-    [Chains.kovan.id]: "0xc4676f88663360155c2bc6d2A482E34121a50b3b",
     [Chains.arbitrumOne.id]: "0x46D06cf8052eA6FdbF71736AF33eD23686eA1452",
 };
 

--- a/components/v1/MarketMetadata.ts
+++ b/components/v1/MarketMetadata.ts
@@ -25,31 +25,32 @@ export type Metadata = {
 export type MarketMetadata = Record<string, Metadata>;
 export type MarketMetadataRecord = Record<number, MarketMetadata>;
 export const Metadata: MarketMetadataRecord = {
-    [Chains.kovan.id]: {
-        ["0xc4676f88663360155c2bc6d2A482E34121a50b3b"]: {
-            title: "DEMOETHRISE",
-            subtitle: "ETH Leverage Market",
-            logo: "/markets/ethrise.png",
-            vaultLogo: "/markets/usdc.png",
-            vaultAddress: "0x42B6BAE111D9300E19F266Abf58cA215f714432c",
-            vaultTitle: "DrvETHUSDC",
-            path: "/markets/ethrise",
-            description: "Enjoy leveraged ETH without risk of liquidation or earn yield from your idle USDC",
-            informationText:
-                "ETHRISE is a leveraged token that goes 2x long ETH. It generates 1.75x-2.5x leveraged gains when the price of ETH rises.",
-            vaultInformationText:
-                "rvETHUSDC is an interest-bearing token that increase value overtime. Start earning variable interest rate in real time by depositing USDC.",
-            collateralSymbol: "ETH",
-            collateralDecimals: 18, // ETH is 18 decimals
-            collateralAddress: "0x4470E84Ce5C1fe89EA35a19560b6f2b1Ed71507f",
-            debtSymbol: "USDC",
-            debtDecimals: 6, // USDC is 6 decimals
-            debtAddress: "0x0af08696cb51e81456dc0a1dee7f8bfad8d82a22",
-            uniswapSwapURL: "https://app.uniswap.org/#/swap?outputCurrency=0xc4676f88663360155c2bc6d2A482E34121a50b3b&chain=kovan",
-            oracleAddress: "0x1F6Ec9B472b5EB3c7aA617Ce45ea2ed4f1A2db7D",
-            isETH: true,
-        },
-    },
+    /* Kovan chain is no longer supported */
+    // [Chains.kovan.id]: {
+    //     ["0xc4676f88663360155c2bc6d2A482E34121a50b3b"]: {
+    //         title: "DEMOETHRISE",
+    //         subtitle: "ETH Leverage Market",
+    //         logo: "/markets/ethrise.png",
+    //         vaultLogo: "/markets/usdc.png",
+    //         vaultAddress: "0x42B6BAE111D9300E19F266Abf58cA215f714432c",
+    //         vaultTitle: "DrvETHUSDC",
+    //         path: "/markets/ethrise",
+    //         description: "Enjoy leveraged ETH without risk of liquidation or earn yield from your idle USDC",
+    //         informationText:
+    //             "ETHRISE is a leveraged token that goes 2x long ETH. It generates 1.75x-2.5x leveraged gains when the price of ETH rises.",
+    //         vaultInformationText:
+    //             "rvETHUSDC is an interest-bearing token that increase value overtime. Start earning variable interest rate in real time by depositing USDC.",
+    //         collateralSymbol: "ETH",
+    //         collateralDecimals: 18, // ETH is 18 decimals
+    //         collateralAddress: "0x4470E84Ce5C1fe89EA35a19560b6f2b1Ed71507f",
+    //         debtSymbol: "USDC",
+    //         debtDecimals: 6, // USDC is 6 decimals
+    //         debtAddress: "0x0af08696cb51e81456dc0a1dee7f8bfad8d82a22",
+    //         uniswapSwapURL: "https://app.uniswap.org/#/swap?outputCurrency=0xc4676f88663360155c2bc6d2A482E34121a50b3b&chain=kovan",
+    //         oracleAddress: "0x1F6Ec9B472b5EB3c7aA617Ce45ea2ed4f1A2db7D",
+    //         isETH: true,
+    //     },
+    // },
     [Chains.arbitrumOne.id]: {
         ["0x46D06cf8052eA6FdbF71736AF33eD23686eA1452"]: {
             title: "ETHRISE",

--- a/components/v1/PortfolioPage/PortfolioPage.tsx
+++ b/components/v1/PortfolioPage/PortfolioPage.tsx
@@ -21,7 +21,6 @@ import { useVaultExchangeRate } from "../swr/useVaultExchangeRate";
 
 // ETHRISE Token ids
 const ETHRISEAddresses = {
-    [Chains.kovan.id]: "0xc4676f88663360155c2bc6d2A482E34121a50b3b",
     [Chains.arbitrumOne.id]: "0x46D06cf8052eA6FdbF71736AF33eD23686eA1452",
 };
 

--- a/components/v1/PortfolioPage/PortfolioPageV2.tsx
+++ b/components/v1/PortfolioPage/PortfolioPageV2.tsx
@@ -17,7 +17,6 @@ import { useVaultExchangeRate } from "../swr/useVaultExchangeRate";
 
 // ETHRISE Token ids
 const ETHRISEAddresses = {
-    [Chains.kovan.id]: "0xc4676f88663360155c2bc6d2A482E34121a50b3b",
     [Chains.arbitrumOne.id]: "0x46D06cf8052eA6FdbF71736AF33eD23686eA1452",
 };
 

--- a/components/v1/Wallet.tsx
+++ b/components/v1/Wallet.tsx
@@ -8,7 +8,7 @@ import { WalletConnectConnector } from "wagmi/connectors/walletConnect";
 
 export const connectorStorageKey = "risedleConnectors.wallet";
 
-export const supportedChains = [Chains.arbitrumOne, Chains.kovan];
+export const supportedChains = [Chains.arbitrumOne];
 export const DEFAULT_CHAIN = Chains.arbitrumOne;
 
 // Wallet connectors
@@ -21,14 +21,12 @@ export const WCConnector = new WalletConnectConnector({
     options: {
         qrcode: true,
         rpc: {
-            [Chains.kovan.id]: "https://eth-kovan.alchemyapi.io/v2/qLbNN95iUDTpQqbm5FzgaSPrPJ908VD-",
             [Chains.arbitrumOne.id]: "https://arb-mainnet.g.alchemy.com/v2/qu4tZ0JUekqqwtcDowbfel-s4S8Z60Oj",
         },
     },
 });
 
 export const ArbitrumOneProvider = new providers.JsonRpcProvider("https://arb-mainnet.g.alchemy.com/v2/qu4tZ0JUekqqwtcDowbfel-s4S8Z60Oj", Chains.arbitrumOne.id);
-export const KovanProvider = new providers.JsonRpcProvider("https://eth-kovan.alchemyapi.io/v2/qLbNN95iUDTpQqbm5FzgaSPrPJ908VD-", Chains.kovan.id);
 
 export type WalletStates = {
     account: string | undefined;
@@ -63,8 +61,6 @@ type WalletGlobalStateProps = {
 
 const getProvider = (config: { chainId?: number }) => {
     switch (config.chainId) {
-        case Chains.kovan.id:
-            return KovanProvider;
         case Chains.arbitrumOne.id:
             return ArbitrumOneProvider;
         default:


### PR DESCRIPTION
## #196  Disable Kovan Network
Kovan Network is no longer supported and not displayed in UI anymore.
![image](https://user-images.githubusercontent.com/81855912/162379127-3050d3be-a93c-4938-9510-66956ec84f16.png)
