### PR TITLE
Change OG Metadata URL to Absolute URL (#204)

### DIFF
--- a/components/v1/MarketDetailPage/MarketDetailPageMeta.tsx
+++ b/components/v1/MarketDetailPage/MarketDetailPageMeta.tsx
@@ -27,7 +27,7 @@ const MarketDetailPage: FunctionComponent<MarketDetailPageProps> = ({ title, pat
             <meta property="og:type" content="website" />
             <meta property="og:title" content={`${title} Market | Risedle Protocol`} />
             <meta property="og:description" content="Leverage ETH or earn yield from your idle USDC" />
-            <meta property="og:image" content={`/assets/images/og/${title}.png`} />
+            <meta property="og:image" content={`https://risedle.com/assets/images/og/${title}.png`} />
 
             {/* <!-- Twitter Meta Tags --> */}
             <meta name="twitter:card" content="summary_large_image" />
@@ -35,7 +35,7 @@ const MarketDetailPage: FunctionComponent<MarketDetailPageProps> = ({ title, pat
             <meta property="twitter:url" content={`https://risedle.com${path}`} />
             <meta name="twitter:title" content={`${title} Market | Risedle Protocol`} />
             <meta name="twitter:description" content="Leverage ETH or earn yield from your idle USDC" />
-            <meta name="twitter:image" content={`/assets/images/og/${title}.png`} />
+            <meta name="twitter:image" content={`https://risedle.com/assets/images/og/${title}.png`} />
         </>
     );
 };

--- a/components/v1/MarketsPage/MarketsPageMeta.tsx
+++ b/components/v1/MarketsPage/MarketsPageMeta.tsx
@@ -19,7 +19,7 @@ const MarketsPageMeta: FunctionComponent<MarketsPageMetaProps> = ({}) => {
             <meta property="og:type" content="website" />
             <meta property="og:title" content="Risedle Protocol" />
             <meta property="og:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta property="og:image" content="/assets/images/og/Markets.png" />
+            <meta property="og:image" content="https://risedle.com/assets/images/og/Markets.png" />
 
             {/* <!-- Twitter Meta Tags --> */}
             <meta name="twitter:card" content="summary_large_image" />
@@ -27,7 +27,7 @@ const MarketsPageMeta: FunctionComponent<MarketsPageMetaProps> = ({}) => {
             <meta property="twitter:url" content="https://risedle.com/" />
             <meta name="twitter:title" content="Risedle Protocol" />
             <meta name="twitter:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta name="twitter:image" content="/assets/images/og/Markets.png" />
+            <meta name="twitter:image" content="https://risedle.com/assets/images/og/Markets.png" />
         </>
     );
 };

--- a/components/v1/PortfolioPage/PortfolioPageMeta.tsx
+++ b/components/v1/PortfolioPage/PortfolioPageMeta.tsx
@@ -24,7 +24,7 @@ const PortofolioPageMeta: FunctionComponent<PortofolioPageMetaProps> = ({}) => {
             <meta property="og:type" content="website" />
             <meta property="og:title" content="Risedle Protocol" />
             <meta property="og:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta property="og:image" content="/assets/images/og/Portfolio.png" />
+            <meta property="og:image" content="https://risedle.com/assets/images/og/Portfolio.png" />
 
             {/* <!-- Twitter Meta Tags --> */}
             <meta name="twitter:card" content="summary_large_image" />
@@ -32,7 +32,7 @@ const PortofolioPageMeta: FunctionComponent<PortofolioPageMetaProps> = ({}) => {
             <meta property="twitter:url" content="https://risedle.com/portofolio" />
             <meta name="twitter:title" content="Risedle Protocol" />
             <meta name="twitter:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta name="twitter:image" content="/assets/images/og/Portfolio.png" />
+            <meta name="twitter:image" content="https://risedle.com/assets/images/og/Portfolio.png" />
         </>
     );
 };

--- a/modules/homePage/component/HomePageMeta.tsx
+++ b/modules/homePage/component/HomePageMeta.tsx
@@ -19,7 +19,7 @@ const HomePageMeta: FunctionComponent<HomePageMetaProps> = ({}) => {
             <meta property="og:type" content="website" />
             <meta property="og:title" content="Risedle Protocol" />
             <meta property="og:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta property="og:image" content="/assets/images/og/Landing.png" />
+            <meta property="og:image" content="https://risedle.com/assets/images/og/Landing.png" />
 
             {/* <!-- Twitter Meta Tags --> */}
             <meta name="twitter:card" content="summary_large_image" />
@@ -27,7 +27,7 @@ const HomePageMeta: FunctionComponent<HomePageMetaProps> = ({}) => {
             <meta property="twitter:url" content="https://risedle.com/" />
             <meta name="twitter:title" content="Risedle Protocol" />
             <meta name="twitter:description" content="Invest, earn and build on the decentralized crypto leveraged ETFs market protocol" />
-            <meta name="twitter:image" content="/assets/images/og/Landing.png" />
+            <meta name="twitter:image" content="https://risedle.com/assets/images/og/Landing.png" />
         </>
     );
 };


### PR DESCRIPTION
# #204 Change OG Metadata URL to Absolute URL
### Fixed URLs in HomePage, MarketsPage, MarketsDetailPage, and PortfolioPage
URL Before:
`/assets/images/og/Landing.png`
URL After:
`https://risedle.com/assets/images/og/Landing.png`