### PR TITLE
[Open Discussion] Handle Select Network & Change Network on Connect

### DIFF
--- a/components/v1/Buttons/ConnectWalletDesktop.tsx
+++ b/components/v1/Buttons/ConnectWalletDesktop.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import * as Dialog from "@radix-ui/react-dialog";
-import { FunctionComponent, useEffect } from "react";
+import { FunctionComponent } from "react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { InjectedConnector } from "wagmi";
@@ -41,10 +41,6 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
     const showConnectWallet = account ? false : true;
     const showSwitchToDefaultNetwork = !showConnectWallet && chain.unsupported ? true : false;
     const showAccountData = !showConnectWallet && !showSwitchToDefaultNetwork;
-
-    useEffect(() => {
-        console.log(switchNetwork);
-    }, [switchNetwork]);
 
     // Connect wallet
     const connect = async function (c: InjectedConnector | WalletConnectConnector) {

--- a/components/v1/Buttons/ConnectWalletDesktop.tsx
+++ b/components/v1/Buttons/ConnectWalletDesktop.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 import * as Dialog from "@radix-ui/react-dialog";
-import { FunctionComponent } from "react";
+import { FunctionComponent, useEffect } from "react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { InjectedConnector } from "wagmi";
 import { getButtonType } from "../../../utils/getButtonType";
 import { WalletConnectConnector } from "wagmi/connectors/walletConnect";
 import * as Popover from "@radix-ui/react-popover";
+import { manualSwitchNetwork } from "../../../utils/changeNetwork";
 import ButtonConnectWallet from "../../../uikit/button/ButtonConnectWallet";
 
 // Toasts
@@ -29,7 +30,7 @@ type ButtonConnectWalletDesktopProps = {};
  */
 const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopProps> = ({}) => {
     // Read global states
-    const { chain, account, connectWallet, disconnectWallet, switchNetwork } = useWalletContext();
+    const { chain, account, connectWallet, disconnectWallet, switchNetwork, selectedNetwork } = useWalletContext();
 
     // Local states
     const [isOpen, setIsOpen] = useState(false);
@@ -40,6 +41,10 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
     const showConnectWallet = account ? false : true;
     const showSwitchToDefaultNetwork = !showConnectWallet && chain.unsupported ? true : false;
     const showAccountData = !showConnectWallet && !showSwitchToDefaultNetwork;
+
+    useEffect(() => {
+        console.log(switchNetwork);
+    }, [switchNetwork]);
 
     // Connect wallet
     const connect = async function (c: InjectedConnector | WalletConnectConnector) {
@@ -92,6 +97,7 @@ const ButtonConnectWalletDesktop: FunctionComponent<ButtonConnectWalletDesktopPr
                                 disabled={isConnecting && connectorName ? true : false}
                                 onClick={async () => {
                                     await connect(MetaMaskConnector);
+                                    await manualSwitchNetwork(selectedNetwork.id);
                                 }}
                             >
                                 <div>

--- a/components/v1/Buttons/ConnectWalletMobile.tsx
+++ b/components/v1/Buttons/ConnectWalletMobile.tsx
@@ -53,6 +53,7 @@ const ButtonConnectWalletMobile: FunctionComponent<ButtonConnectWalletMobileProp
                     toast.custom((t) => <ToastError>{result.error.message}</ToastError>);
                     return;
                 }
+                selectNetwork(c);
                 toast.remove();
                 toast.custom((t) => <ToastSuccess>Switched to {c.name}</ToastSuccess>);
             } else {

--- a/components/v1/Buttons/NetworkSwitcher.tsx
+++ b/components/v1/Buttons/NetworkSwitcher.tsx
@@ -38,6 +38,7 @@ const ButtonNetworkSwitcher: FunctionComponent<ButtonNetworkSwitcherProps> = ({}
                     toast.custom((t) => <ToastError>{result.error.message}</ToastError>);
                     return;
                 }
+                selectNetwork(c);
                 toast.remove();
                 toast.custom((t) => <ToastSuccess>Switched to {c.name}</ToastSuccess>);
             } else {

--- a/components/v1/Buttons/NetworkSwitcher.tsx
+++ b/components/v1/Buttons/NetworkSwitcher.tsx
@@ -24,27 +24,32 @@ type ButtonNetworkSwitcherProps = {};
  */
 const ButtonNetworkSwitcher: FunctionComponent<ButtonNetworkSwitcherProps> = ({}) => {
     // Read global states
-    const { account, chain, switchNetwork } = useWalletContext();
+    const { account, selectNetwork, chain, switchNetwork } = useWalletContext();
 
     // Local state
     const [isOpen, setIsOpen] = useState(false);
 
-    const switchToNetwork = async (c: Chain) => {
-        if (switchNetwork) {
-            const result = await switchNetwork(c.id);
-            if (result.error) {
+    const handleSelectNetwork = async (c: Chain) => {
+        if (account) {
+            if (switchNetwork) {
+                const result = await switchNetwork(c.id);
+                if (result.error) {
+                    toast.remove();
+                    toast.custom((t) => <ToastError>{result.error.message}</ToastError>);
+                    return;
+                }
                 toast.remove();
-                toast.custom((t) => <ToastError>{result.error.message}</ToastError>);
+                toast.custom((t) => <ToastSuccess>Switched to {c.name}</ToastSuccess>);
+            } else {
+                toast.remove();
+                toast.custom((t) => <ToastError>Cannot switch network automatically in WalletConnect. Please change network directly from your wallet.</ToastError>);
                 return;
             }
+        } else {
+            selectNetwork(c);
             toast.remove();
             toast.custom((t) => <ToastSuccess>Switched to {c.name}</ToastSuccess>);
-        } else {
-            toast.remove();
-            toast.custom((t) => <ToastError>Cannot switch network automatically in WalletConnect. Please change network directly from your wallet.</ToastError>);
-            return;
         }
-        return;
     };
 
     return (
@@ -53,11 +58,6 @@ const ButtonNetworkSwitcher: FunctionComponent<ButtonNetworkSwitcherProps> = ({}
                 <Dialog.Trigger
                     className="button basic p-0"
                     onClick={() => {
-                        if (!account) {
-                            toast.remove();
-                            toast.custom((t) => <ToastError>Please connect your wallet first</ToastError>);
-                            return;
-                        }
                         setIsOpen(true);
                     }}
                 >
@@ -81,8 +81,8 @@ const ButtonNetworkSwitcher: FunctionComponent<ButtonNetworkSwitcherProps> = ({}
                                         return (
                                             <button
                                                 className="m-0 flex w-full flex-row items-center space-x-4 rounded-[12px] border border-gray-light-5 bg-gray-light-2 py-[11px] px-[11px] text-left dark:border-gray-dark-5 dark:bg-gray-dark-2"
-                                                onClick={async () => {
-                                                    await switchToNetwork(c);
+                                                onClick={() => {
+                                                    handleSelectNetwork(c);
                                                     setIsOpen(false);
                                                 }}
                                                 key={c.id}

--- a/modules/marketsPage/MarketsPageContainer.tsx
+++ b/modules/marketsPage/MarketsPageContainer.tsx
@@ -9,7 +9,7 @@ import Footer from "../../uikit/layout/Footer";
 import MarketCard from "./components/MarketCard";
 import ButtonConnectWalletMobile from "../../components/v1/Buttons/ConnectWalletMobile";
 import MarketsPageMeta from "./components/MarketsPageMeta";
-import { DEFAULT_CHAIN, useWalletContext } from "../../components/v1/Wallet";
+import { useWalletContext } from "../../components/v1/Wallet";
 import { useMarkets } from "../../components/v1/swr/useMarkets";
 import Navigation from "../../components/v1/Navigation";
 import WarningHeader from "./components/WarningHeader";
@@ -26,10 +26,10 @@ type MarketsPageContainerProps = {};
  */
 const MarketsPageContainer: FunctionComponent<MarketsPageContainerProps> = ({}) => {
     // Read global states
-    const { chain } = useWalletContext();
+    const { chain, selectedNetwork } = useWalletContext();
 
     // Read data from Snapshot API
-    const marketsResponse = useMarkets(chain.unsupported ? DEFAULT_CHAIN.id : chain.chain.id);
+    const marketsResponse = useMarkets(chain.unsupported ? selectedNetwork.id : chain.chain.id);
 
     // UI states
     const showLoading = marketsResponse.isLoading;

--- a/modules/marketsPage/components/BackgroundGradient.tsx
+++ b/modules/marketsPage/components/BackgroundGradient.tsx
@@ -14,7 +14,7 @@ type BackgroundGradientProps = {};
  */
 
 const BackgroundGradient: FunctionComponent<BackgroundGradientProps> = ({}) => {
-    const { chain } = useWalletContext();
+    const { selectedNetwork } = useWalletContext();
     return (
         <>
             <div className="absolute -top-[56%] left-1/2 -translate-x-1/2 sm:-top-1/2">
@@ -27,13 +27,13 @@ const BackgroundGradient: FunctionComponent<BackgroundGradientProps> = ({}) => {
                     </g>
                 </svg>
             </div>
-            {chain.chain.id === customChains.bsc.id && (
+            {selectedNetwork.id === customChains.bsc.id && (
                 <div className="absolute -top-3/4 left-1/2 h-max w-max -translate-x-1/2 sm:-top-2/3">
                     <img src="/assets/images/marketspage/gradient-bsc-dark.svg" className="hidden dark:block" />
                     <img src="/assets/images/marketspage/gradient-bsc-light.svg" className="dark:hidden" />
                 </div>
             )}
-            {chain.chain.id === Chains.arbitrumOne.id && (
+            {selectedNetwork.id === Chains.arbitrumOne.id && (
                 <div className="absolute -top-3/4 left-1/2 h-max w-max -translate-x-1/2 sm:-top-2/3">
                     <img src="/assets/images/marketspage/gradient-arb-dark.svg" className="hidden dark:block" />
                     <img src="/assets/images/marketspage/gradient-arb-light.svg" className="dark:hidden" />

--- a/modules/marketsPage/components/WarningHeader.tsx
+++ b/modules/marketsPage/components/WarningHeader.tsx
@@ -14,7 +14,7 @@ type WarningHeaderProps = {};
  */
 
 const WarningHeader: FunctionComponent<WarningHeaderProps> = ({}) => {
-    const { chain } = useWalletContext();
+    const { selectedNetwork } = useWalletContext();
 
     const getBscLogo = (type: "normal" | "gray") => {
         return (
@@ -25,7 +25,7 @@ const WarningHeader: FunctionComponent<WarningHeaderProps> = ({}) => {
     };
 
     return (
-        <div className={`${chain.chain.id !== customChains.bsc.id && "hidden"} z-10 flex w-max min-w-full flex-row gap-8 border-b border-gray-light-4 bg-[#FFF9ED]/40 px-4 py-3 backdrop-blur-[102px] dark:border-gray-dark-4 dark:bg-gray-dark-1/40`}>
+        <div className={`${selectedNetwork.id !== customChains.bsc.id && "hidden"} z-10 flex w-max min-w-full flex-row gap-8 border-b border-gray-light-4 bg-[#FFF9ED]/40 px-4 py-3 backdrop-blur-[102px] dark:border-gray-dark-4 dark:bg-gray-dark-1/40`}>
             {[...Array(10)].map(() => {
                 return (
                     <>

--- a/utils/changeNetwork.tsx
+++ b/utils/changeNetwork.tsx
@@ -1,65 +1,23 @@
-import { chain } from "wagmi";
+import { Chain, chain } from "wagmi";
+import { customChains } from "../components/v1/Wallet";
 
-// Get the Arbitrum URL from .env file
-let arbitrumURL = "";
-if (process.env.NEXT_PUBLIC_ARBITRUM_URL) {
-    arbitrumURL = process.env.NEXT_PUBLIC_ARBITRUM_URL;
-}
-
-// Get the Kovan URL from .env file
-let kovanURL = "";
-if (process.env.NEXT_PUBLIC_KOVAN_URL) {
-    kovanURL = process.env.NEXT_PUBLIC_KOVAN_URL;
-}
-
-export const changeToArbitrum = async () => {
-    const metamask = window.ethereum;
-    try {
-        await metamask?.request({
-            method: "wallet_addEthereumChain",
-            params: [
-                {
-                    chainId: `0x${chain.arbitrumOne.id.toString(16)}`,
-                    chainName: "Arbitrum Mainnet",
-                    nativeCurrency: {
-                        name: "AETH",
-                        symbol: "aeth",
-                        decimals: 18,
-                    },
-                    rpcUrls: [arbitrumURL],
-                    blockExplorerUrls: ["https://arbiscan.io/"],
-                },
-            ],
-        });
-    } catch (error) {
-        console.log(error);
-        await metamask?.request({
-            method: "wallet_switchEthereumChain",
-            params: [
-                {
-                    chainId: `0x${chain.arbitrumOne.id.toString(16)}`,
-                },
-            ],
-        });
-    }
+const networkInfo: Record<number, Chain> = {
+    [customChains.bsc.id]: customChains.bsc,
+    [chain.arbitrumOne.id]: chain.arbitrumOne,
 };
 
-export const changeToKovan = async () => {
+export const manualSwitchNetwork = async (chain: number) => {
     const metamask = window.ethereum;
     try {
         await metamask?.request({
             method: "wallet_addEthereumChain",
             params: [
                 {
-                    chainId: `0x${chain.kovan.id.toString(16)}`,
-                    chainName: "Kovan Test Network",
-                    nativeCurrency: {
-                        name: "ETH",
-                        symbol: "eth",
-                        decimals: 18,
-                    },
-                    rpcUrls: [kovanURL],
-                    blockExplorerUrls: ["https://kovan.etherscan.io/"],
+                    chainId: `0x${networkInfo[chain].id.toString(16)}`,
+                    chainName: networkInfo[chain].name,
+                    nativeCurrency: networkInfo[chain].nativeCurrency,
+                    rpcUrls: networkInfo[chain].rpcUrls,
+                    blockExplorerUrls: networkInfo[chain].blockExplorers?.map((item) => item.url),
                 },
             ],
         });
@@ -69,7 +27,7 @@ export const changeToKovan = async () => {
             method: "wallet_switchEthereumChain",
             params: [
                 {
-                    chainId: `0x${chain.kovan.id.toString(16)}`,
+                    chainId: `0x${networkInfo[chain].id.toString(16)}`,
                 },
             ],
         });


### PR DESCRIPTION
# Metamask
## Before
Users are required to connect their wallet first if they want to change network. If they have connected their wallet and change to different network from UI, a metamask prompt will appear and user can approve the change network on metamask.

## Now
User can choose a network via UI before even connecting their wallet to Risedle. If the network in user's is not the same as what they've chosen on UI (let's say they choose BSC in UI, but the network is Ethereum Mainnet on their metamask), a switch network metamask prompt will appear after user connect their wallet.

# WalletConnect
WalletConnect behavior is not changed. User have to choose the right network manually form their wallet to be able to connect to risedle. If the network is wrong (not Arbitrum or BSC), then a toast message will appear and tell the user to change the network on their wallet manually.